### PR TITLE
attach error-information to url on redirect

### DIFF
--- a/src/OAuth2/HttpFoundationBridge/Response.php
+++ b/src/OAuth2/HttpFoundationBridge/Response.php
@@ -47,29 +47,20 @@ use OAuth2\ResponseInterface;
 
     public function setRedirect($statusCode = 302, $url, $state = null, $error = null, $errorDescription = null, $errorUri = null)
     {
-        $url = parse_url($url);
-        parse_str(isset($url['query']) ? $url['query'] : '', $url['query']);
-
         $this->setStatusCode($statusCode);
         $this->setContent(null);
 
-        if ($error) {
-            $url['query']['error'] = $error;
+        $query = array(
+            'state'             => $state,
+            'error'             => $error,
+            'error_description' => $errorDescription,
+            'error_uri'         => $errorUri
+        );
+
+        if ($queryStr = http_build_query(array_filter($query))) {
+            $url .= (false === strpos($url, '?') ? '?' : '&').$queryStr;
         }
 
-        if ($errorDescription) {
-            $url['query']['error_description'] = $errorDescription;
-        }
-
-        if ($error) {
-            $url['query']['error_uri'] = $errorUri;
-        }
-
-        $redirect = sprintf('%s://%s%s', $url['scheme'], $url['host'], isset($url['path']) ? $url['path'] : '');
-        if ($query = http_build_query($url['query'])) {
-            $redirect .= '?'.$query;
-        }
-
-        $this->headers->set('Location', $redirect);
+        $this->headers->set('Location', $url);
     }
  }


### PR DESCRIPTION
i had the same problem as @zerrvox at #7

after declining (implicit, for the sake of simplicity) the response looked like the following one:

```
$ curl 'api.hfcit.dev/oauth/authorize?response_type=code&client_id=4a69dd44-fdf4-4c34-8fae-b8ef40818657&redirect_uri=http://foo.bar&state=123' | json
HTTP/1.1 302 Found
Server: nginx/1.7.0
Content-Type: application/json
Transfer-Encoding: chunked
Connection: keep-alive
Cache-Control: no-cache
Date: Sun, 27 Apr 2014 17:47:37 GMT
Location: http://foo.bar

{
    "error": "access_denied",
    "error_description": "The user denied access to your application"
}
```

after the included modification, it goes like this:

```
$ curl 'api.hfcit.dev/oauth/authorize?response_type=code&client_id=4a69dd44-fdf4-4c34-8fae-b8ef40818657&redirect_uri=http%3A%2F%2Ffoo.bar%2Fpath%3Fkey%3Dvalue&state=123'
HTTP/1.1 302 Found
Server: nginx/1.7.0
Content-Type: application/json
Transfer-Encoding: chunked
Connection: keep-alive
Cache-Control: no-cache
Date: Sun, 27 Apr 2014 18:01:33 GMT
Location: http://foo.bar/path?key=value&error=access_denied&error_description=The+user+denied+access+to+your+application
```

that is how we should handle it :)

@bshaffer WDYT?
