### PR TITLE
Use $bridgeRequest in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ function to build the OAuth2\HttpFoundationBridge\Request instance:
     {
         //... (instantiate server/response objects)
         $bridgeRequest = BridgeRequest::createFromRequest($request);
-        $server->grantAccessToken($request, $response);
+        $server->grantAccessToken($bridgeRequest, $response);
     }
 
 ## Creating the response


### PR DESCRIPTION
I haven't used this, but doesn't this need to be `$bridgeRequest` instead of `$request`?
