### PR TITLE
Apache Authorization header fix applied to constructor and incidently…

### DIFF
--- a/src/OAuth2/HttpFoundationBridge/Request.php
+++ b/src/OAuth2/HttpFoundationBridge/Request.php
@@ -10,6 +10,12 @@ use OAuth2\RequestInterface;
  */
  class Request extends BaseRequest implements RequestInterface
  {
+    public function initialize(array $query = array(), array $request = array(), array $attributes = array(), array $cookies = array(), array $files = array(), array $server = array(), $content = null)
+    {
+        parent::initialize($query, $request, $attributes, $cookies, $files, $server, $content);
+        self::fixAuthHeader($this->headers);
+    }
+
     public function query($name, $default = null)
     {
         return $this->query->get($name, $default);


### PR DESCRIPTION
… to createFromRequest

follows up 82aec77c5d63b968ec67d16714e4bd209f28f438 which did not fix the problem when using Request::createFromRequest() to create bridge request object.