### PR TITLE
Adjust travis config to main project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: php
 php:
-- 5.3
 - 5.4
 - 5.5
 - 5.6
 - 7.0
 - 7.1
-- hhvm
+- 7.2
 script:
-- phpunit
-before_script:
+- vendor/bin/phpunit
+install:
 - composer install

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,12 @@
     ],
     "homepage": "http://github.com/bshaffer/oauth2-server-httpfoundation-bridge",
     "require":{
-        "php":">=5.3.0",
+        "php":">=5.3.9",
         "symfony/http-foundation": ">=2.1",
         "bshaffer/oauth2-server-php": ">=0.9"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.0"
     },
     "autoload": {
         "psr-0": { "OAuth2\\HttpFoundationBridge": "src/" }

--- a/src/OAuth2/HttpFoundationBridge/Response.php
+++ b/src/OAuth2/HttpFoundationBridge/Response.php
@@ -59,7 +59,7 @@ use OAuth2\ResponseInterface;
         if ($params) {
             // add the params to the URL
             $parts = parse_url($url);
-            $sep = isset($parts['query']) && count($parts['query']) > 0 ? '&' : '?';
+            $sep = isset($parts['query']) ? '&' : '?'; //If query part already exits & chaining is required
             $url .= $sep . http_build_query($params);
         }
 

--- a/test/OAuth2/HttpFoundationBridge/RequestTest.php
+++ b/test/OAuth2/HttpFoundationBridge/RequestTest.php
@@ -2,7 +2,9 @@
 
 namespace OAuth2\HttpFoundationBridge;
 
-class RequestTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class RequestTest extends TestCase
 {
     public function testFixAuthHeader()
     {

--- a/test/OAuth2/HttpFoundationBridge/ResponseTest.php
+++ b/test/OAuth2/HttpFoundationBridge/ResponseTest.php
@@ -2,7 +2,9 @@
 
 namespace OAuth2\HttpFoundationBridge;
 
-class ResponseTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ResponseTest extends TestCase
 {
     /** @dataProvider provideAddParameters */
     public function testAddParameters($expected, $parameters, $content = null)


### PR DESCRIPTION
To get travis builds working following changes are mainly taken from main project:

- add phpunit in composer.json
- add php 7.2 to .travis.yml and remove hhvm and 5.3
- using vendor phpunit in .travis.yml
- changed superclasses in tests according to phpunit version
- removed a count() call in response to get php 7.2 working

Maybe the last point could be solved better but the solution is sufficent for given tests.