### PR TITLE
allow overriding from fixAuthHeader function

### DIFF
--- a/src/OAuth2/HttpFoundationBridge/Request.php
+++ b/src/OAuth2/HttpFoundationBridge/Request.php
@@ -61,7 +61,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
         $request = parent::createFromGlobals();
         
         //fix the bug.
-        self::fixAuthHeader($request->headers);
+        static::fixAuthHeader($request->headers);
         
         return $request;
     }


### PR DESCRIPTION
call fixAuthHeader in createFromGlobals with static instead of self