### PR TITLE
Make Response compatible with HttpFoundation 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-dist: precise
+dist: trusty
 php:
 - 7.2
 - 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 language: php
 dist: precise
 php:
-- 5.3
-- 5.4
-- 5.5
-- 5.6
-- 7.0
-- 7.1
 - 7.2
+- 7.3
+- 7.4
 script:
 - vendor/bin/phpunit
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     ],
     "homepage": "http://github.com/bshaffer/oauth2-server-httpfoundation-bridge",
     "require":{
-        "php":">=5.3.0",
+        "php":">=7.0.0",
         "bshaffer/oauth2-server-php": ">=0.9",
-        "symfony/http-foundation": ">=2.1"
+        "symfony/http-foundation": ">=5.0"
     },
     "autoload": {
         "psr-0": { "OAuth2\\HttpFoundationBridge": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "homepage": "http://github.com/bshaffer/oauth2-server-httpfoundation-bridge",
     "require":{
-        "php":">=7.0.0",
+        "php":">=7.2.0",
         "bshaffer/oauth2-server-php": ">=0.9",
         "symfony/http-foundation": ">=5.0"
     },

--- a/src/OAuth2/HttpFoundationBridge/Response.php
+++ b/src/OAuth2/HttpFoundationBridge/Response.php
@@ -69,7 +69,7 @@ class Response extends JsonResponse implements ResponseInterface
     /**
      * @param int $statusCode
      */
-    public function setStatusCode($statusCode, $text = null)
+    public function setStatusCode($statusCode, $text = null): object
     {
         return parent::setStatusCode($statusCode);
     }


### PR DESCRIPTION
Symfony HttpFoundation version 5.0 added a return type declaration to the setStatusCode function, which results in the following error when used together with version 1.4 of the bridge component:

> PHP Fatal error:  Declaration of OAuth2\HttpFoundationBridge\Response::setStatusCode($statusCode, $text = NULL) must be compatible with Symfony\Component\HttpFoundation\Response::setStatusCode(int $code, $text = NULL): object

This pull request attempts to resolve this by:

- adding the necessary return type declaration (`object` in this case)
- updating the required PHP version to `>=7.0.0` (which introduces return type declarations)
- updating the required symfony/http-foundation package to `^5.0`

Since this introduces backwards incompatible changes, I suggest to bump the version number to 2.0