### PR TITLE
a default value followed by a required parameter is deprecated in PHP8

### DIFF
--- a/src/OAuth2/HttpFoundationBridge/Response.php
+++ b/src/OAuth2/HttpFoundationBridge/Response.php
@@ -45,7 +45,7 @@ class Response extends JsonResponse implements ResponseInterface
         )));
     }
 
-    public function setRedirect($statusCode = 302, $url, $state = null, $error = null, $errorDescription = null, $errorUri = null)
+    public function setRedirect($statusCode, $url, $state = null, $error = null, $errorDescription = null, $errorUri = null)
     {
         $this->setStatusCode($statusCode);
 


### PR DESCRIPTION
Fixes #38 

> If a parameter with a default value is followed by a required parameter, the default value has no effect. This is deprecated as of PHP 8.0.0 and can generally be resolved by dropping the default value, without a change in functionality

https://www.php.net/manual/en/migration80.deprecated.php