### PR TITLE
adjust type hint for Symfony 6

### DIFF
--- a/src/OAuth2/HttpFoundationBridge/Request.php
+++ b/src/OAuth2/HttpFoundationBridge/Request.php
@@ -52,11 +52,9 @@ class Request extends BaseRequest implements RequestInterface
      * Overwrite to fix an apache header bug. Read more here:
      * http://stackoverflow.com/questions/11990388/request-headers-bag-is-missing-authorization-header-in-symfony-2%E2%80%94
      *
-     * @return Request A new request
-     *
      * @api
      */
-    public static function createFromGlobals()
+    public static function createFromGlobals(): static
     {
         $request = parent::createFromGlobals();
 

--- a/src/OAuth2/HttpFoundationBridge/Response.php
+++ b/src/OAuth2/HttpFoundationBridge/Response.php
@@ -66,10 +66,7 @@ class Response extends JsonResponse implements ResponseInterface
         $this->headers->set('Location', $url);
     }
 
-    /**
-     * @param int $statusCode
-     */
-    public function setStatusCode($statusCode, $text = null): object
+    public function setStatusCode(int $statusCode, ?string $text = null): static
     {
         return parent::setStatusCode($statusCode);
     }


### PR DESCRIPTION
Symfony 6 introduced type hints. This pull request fixes the following errors:

```
Declaration of OAuth2\HttpFoundationBridge\Request::createFromGlobals() must be compatible with Symfony\Component\HttpFoundation\Request::createFromGlobals(): static
public static function createFromGlobals(): static

Declaration of OAuth2\HttpFoundationBridge\Response::setStatusCode($statusCode, $text = null): object must be compatible with Symfony\Component\HttpFoundation\Response::setStatusCode(int $code, ?string $text = null): static
public function setStatusCode(int $statusCode, ?string $text = null): static 
```