### PR TITLE
chore: update deps to new minimum versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     "homepage": "http://github.com/bshaffer/oauth2-server-httpfoundation-bridge",
     "require":{
         "php":">=8.0",
-        "bshaffer/oauth2-server-php": ">=0.9",
-        "symfony/http-foundation": ">=5.0"
+        "bshaffer/oauth2-server-php": "^1.13",
+        "symfony/http-foundation": "^5.4||^6.0"
     },
     "autoload": {
         "psr-0": { "OAuth2\\HttpFoundationBridge": "src/" }


### PR DESCRIPTION
This library is no longer compatible with certain versions of `bshaffer/oauth2-server-php` and `symfony/http-foundation`